### PR TITLE
Utilize syntax sugar

### DIFF
--- a/src/frontend/lexer.rs
+++ b/src/frontend/lexer.rs
@@ -157,7 +157,7 @@ impl<It: Iterator<Item = IoResult<char>>> Lexer<It> {
         match FromStrRadix::from_str_radix(num, base) {
             Ok(x) => LexerStep::Step(Token::Number(x)),
             Err(e) => self.die(
-                format!("invalid base {} constant {}: {}", base, s, e).as_slice()
+                &format!("invalid base {} constant {}: {}", base, s, e)
                 )
         }
     }
@@ -165,7 +165,7 @@ impl<It: Iterator<Item = IoResult<char>>> Lexer<It> {
     fn read_identifier(&mut self) -> LexerStep {
         let s = self.getc_while(|c| { is_identifier_char(c) });
 
-        match find_keyword(s.as_slice()) {
+        match find_keyword(&s) {
             Some(tok) => LexerStep::Step(tok),
             None      => LexerStep::Step(Token::Identifier(s)),
         }
@@ -358,7 +358,7 @@ impl<It: Iterator<Item = IoResult<char>>> Lexer<It> {
             '"' => self.read_string(),
             '\'' => self.read_char(),
 
-            _ => self.die(format!("lexer error: unexpected char {}", c).as_slice())
+            _ => self.die(&format!("lexer error: unexpected char {}", c))
         } }
     }
 }

--- a/src/frontend/tree.rs
+++ b/src/frontend/tree.rs
@@ -204,7 +204,7 @@ impl DumpContext {
         }
 
         self.put(String::from_str("\n"));
-        for _ in range(0, self.depth) {
+        for _ in (0..self.depth) {
             print!("  ");
         }
         self.blank = true;


### PR DESCRIPTION
This helps lessen the requirements of using `#![feature(core)]`.

The only remaining requirement is the usage of `FromStrRadix`. If this API is stabilized, or worked around, we can remove `#![feature(core)]` from `src/gx.rs`.