### PR TITLE
Teach gx to accept multiple input files

### DIFF
--- a/src/frontend/lexer.rs
+++ b/src/frontend/lexer.rs
@@ -6,7 +6,7 @@
 
 //! Lexer for the `gx` language. Very simple lexer.
 
-use std::old_io::IoResult;
+use std::io;
 use std::num::FromStrRadix;
 
 use frontend::token::*;
@@ -63,7 +63,7 @@ enum LexerStep {
     EndOfInput,
 }
 
-impl<It: Iterator<Item = IoResult<char>>> Lexer<It> {
+impl<It: Iterator<Item = Result<char, io::CharsError>>> Lexer<It> {
     pub fn new(input: It) -> Lexer<It> {
         Lexer {
             input: input,
@@ -363,7 +363,7 @@ impl<It: Iterator<Item = IoResult<char>>> Lexer<It> {
     }
 }
 
-impl<It: Iterator<Item = IoResult<char>>> Iterator for Lexer<It> {
+impl<It: Iterator<Item = Result<char, io::CharsError>>> Iterator for Lexer<It> {
     type Item = Token;
 
     fn next(&mut self) -> Option<Token> {


### PR DESCRIPTION
Rather than read from stdin, multiple files will be read using paths
from the command line invocation. Files are parsed separately, then
the resulting `Vec<Decl>` are appended before proceeding as usual.

This moves gx to the new `std::io` API. Additionally, this lays the
framework for using a proper `Result` and `try!()` based API instead of
calling `panic!()` at failure.
